### PR TITLE
win,tty: Change to account for surrogate pairs

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2699,10 +2699,7 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
         abort();
       }
 
-      /* We wouldn't mind emitting utf-16 surrogate pairs. Too bad, the windows
-       * console doesn't really support UTF-16, so just emit the replacement
-       * character. */
-      if (utf8_codepoint > 0xffff) {
+      if (utf8_codepoint > 0x10ffff) {
         utf8_codepoint = UNICODE_REPLACEMENT_CHARACTER;
       }
 
@@ -2731,6 +2728,12 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
         /* Encode character into utf-16 buffer. */
         ENSURE_BUFFER_SPACE(1);
         utf16_buf[utf16_buf_used++] = (WCHAR) utf8_codepoint;
+        previous_eol = 0;
+      } else {
+        ENSURE_BUFFER_SPACE(2);
+        utf8_codepoint -= 0x10000;
+        utf16_buf[utf16_buf_used++] = (WCHAR) (utf8_codepoint / 0x400 + 0xD800);
+        utf16_buf[utf16_buf_used++] = (WCHAR) (utf8_codepoint % 0x400 + 0xDC00);
         previous_eol = 0;
       }
     }


### PR DESCRIPTION
This is a change to resolve https://github.com/neovim/neovim/issues/12580#issuecomment-652561878. This change allows for both mouse and emoji to be used in the latest Windows Terminal. However, if you run it with `conhost.exe`(`cmd.exe`), you can use REPLACEMENT CHARACTER(`U+FFFD`) is no longer displayed. I don't know how to know whether it's running on windows terminal or `conhost`, so for now it can only be one or the other.

When executed with `conhost`, the following display will be displayed, which is the same as before `v1.34.0`. I honestly can't decide if I should apply this or not.

![conhost](https://user-images.githubusercontent.com/11682285/86340726-53796a80-bc90-11ea-8032-33c60aaea86b.png)
